### PR TITLE
apt-get install unzip

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -33,7 +33,8 @@ apt-get install -y \
     atop \
     python-pip \
     curl \
-    jq
+    jq \
+    unzip
 
 # We don't want to upgrade them.
 apt-mark hold kubeadm kubectl kubelet kubernetes-cni docker-ce


### PR DESCRIPTION
HashiCorp software is packaged with zip, so we need unzip.